### PR TITLE
Switch to PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Synchronize tabs, passwords, history etc. between your Firefox instances
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://www.mozilla.org/en-GB/firefox/features/sync/)
-[![Version: 0.23.3~ynh7](https://img.shields.io/badge/Version-0.23.3~ynh7-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/syncserver-rs/)
+[![Version: 0.23.3~ynh9](https://img.shields.io/badge/Version-0.23.3~ynh9-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/syncserver-rs/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/syncserver-rs"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/conf/config.toml
+++ b/conf/config.toml
@@ -7,7 +7,7 @@ port = __PORT__
 
 # Example Syncstorage settings:
 # Example MySQL DSN:
-syncstorage.database_url = "mysql://__DB_USER__:__DB_PWD__@localhost/__DB_NAME__"
+syncstorage.database_url = "postgres://__DB_USER__:__DB_PWD__@localhost/__DB_NAME__"
 # Example Spanner DSN:
 # database_url="spanner://projects/SAMPLE_GCP_PROJECT/instances/SAMPLE_SPANNER_INSTANCE/databases/SAMPLE_SPANNER_DB"
 # enable quota limits
@@ -18,9 +18,9 @@ syncstorage.enabled = true
 syncstorage.limits.max_total_records = 1666 # See issues #298/#333
 
 # Example Tokenserver settings:
-tokenserver.database_url = "mysql://__DB_USER__:__DB_PWD__@localhost/__DB_NAME_TOKENSERVER__"
+tokenserver.database_url = "postgres://__DB_USER__:__DB_PWD__@localhost/__DB_NAME_TOKENSERVER__"
 tokenserver.enabled = true
-tokenserver.node_type = "mysql"
+tokenserver.node_type = "postgres"
 
 tokenserver.fxa_metrics_hash_secret = "__SECRET__"
 tokenserver.fxa_email_domain = "api.accounts.firefox.com"

--- a/manifest.toml
+++ b/manifest.toml
@@ -8,7 +8,7 @@ name = "Firefox SyncStorage"
 description.en = "Synchronize tabs, passwords, history etc. between your Firefox instances"
 description.fr = "Synchronisez for onglets, mot de passe, historique etc entre vos Firefox"
 
-version = "0.23.3~ynh7"
+version = "0.23.3~ynh9"
 
 maintainers = ["orhtej2"]
 
@@ -46,74 +46,74 @@ ram.runtime = "50M"
         autoupdate.needs_manual_tweaks = true
 
         [resources.sources.bookworm]
-        amd64.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/syncserver-0.23.3/syncserver-0.23.3-bookworm-x86_64-unknown-linux-gnu.zst"
-        amd64.sha256 = "d75f0cb4757063f290d225358ee31fcb46247d7957f60069630e1013f843cdc6"
+        amd64.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/syncserver-0.23.3-postgres/syncserver-0.23.3-bookworm-x86_64-unknown-linux-gnu.zst"
+        amd64.sha256 = "2b88b72010b98fb86fab7f86a453c54cd55f2307667bb2acea4c365d4e57e60d"
         autoupdate.asset.amd64 = "syncserver-\\d+(\\.\\d+)+-bookworm-x86_64-unknown-linux-gnu.zst"
 
-        arm64.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/syncserver-0.23.3/syncserver-0.23.3-bookworm-aarch64-unknown-linux-gnu.zst"
-        arm64.sha256 = "63228568c409ee4702d12500b7bd4c9faa5d2bdcd58e96dcb7a36e7ef982ce2a"
+        arm64.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/syncserver-0.23.3-postgres/syncserver-0.23.3-bookworm-aarch64-unknown-linux-gnu.zst"
+        arm64.sha256 = "e55506fd060bd916b530b933769d4700888280946efc65e89dcce548fa6f8928"
         autoupdate.asset.arm64 = "syncserver-\\d+(\\.\\d+)+-bookworm-aarch64-unknown-linux-gnu.zst"
 
-        armhf.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/syncserver-0.23.3/syncserver-0.23.3-bookworm-armv7-unknown-linux-gnueabihf.zst"
-        armhf.sha256 = "d0ada6a7c76abfa9dad489de01da37ab5590b761fb57eb5b1b12398dfd4a2ddb"
+        armhf.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/syncserver-0.23.3-postgres/syncserver-0.23.3-bookworm-armv7-unknown-linux-gnueabihf.zst"
+        armhf.sha256 = "be851ed657c7b3db70b743616a061529ba5cf4bd357da85785200ebd1b5474e4"
         autoupdate.asset.armhf = "syncserver-\\d+(\\.\\d+)+-bookworm-armv7-unknown-linux-gnueabihf.zst"
 
         autoupdate.strategy = "latest_github_release"
         autoupdate.upstream = "https://github.com/YunoHost-Apps/syncstorage-rs-build"
         autoupdate.needs_manual_tweaks = true
-        autoupdate.version_regex = "syncserver-(\\d+\\.\\d+\\.\\d+\\.?\\d{0,})"
+        autoupdate.version_regex = "syncserver-(\\d+\\.\\d+\\.\\d+\\.?\\d{0,})-postgres"
         rename = "syncserver"
         in_subdir = false
         prefetch = false
 
         [resources.sources.trixie]
-        amd64.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/syncserver-0.23.3/syncserver-0.23.3-trixie-x86_64-unknown-linux-gnu.zst"
-        amd64.sha256 = "80c23f5fecc227e98716c6f7149a6fa8bd74bbb455f6788aba0ad1f786e8d6d9"
+        amd64.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/syncserver-0.23.3-postgres/syncserver-0.23.3-trixie-x86_64-unknown-linux-gnu.zst"
+        amd64.sha256 = "c8918eca1615846b514e89667172857d4e8ed4a91b46ddafc562f1eec0477188"
         autoupdate.asset.amd64 = "syncserver-\\d+(\\.\\d+)+-trixie-x86_64-unknown-linux-gnu.zst"
 
-        arm64.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/syncserver-0.23.3/syncserver-0.23.3-trixie-aarch64-unknown-linux-gnu.zst"
-        arm64.sha256 = "7c36469a94d0e476fa143234ba81556691b8d7cdf6b2b3b90c9510e9e5523099"
+        arm64.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/syncserver-0.23.3-postgres/syncserver-0.23.3-trixie-aarch64-unknown-linux-gnu.zst"
+        arm64.sha256 = "84c7e83427b734d5b48e669252d4c58ee1bc31a45616a69f0c11ef1bb80b3594"
         autoupdate.asset.arm64 = "syncserver-\\d+(\\.\\d+)+-trixie-aarch64-unknown-linux-gnu.zst"
 
-        armhf.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/syncserver-0.23.3/syncserver-0.23.3-trixie-armv7-unknown-linux-gnueabihf.zst"
-        armhf.sha256 = "a81fd8bcfe473a2874b1885638800cac5dfd8467a1028f26321f628ac5b1d507"
+        armhf.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/syncserver-0.23.3-postgres/syncserver-0.23.3-trixie-armv7-unknown-linux-gnueabihf.zst"
+        armhf.sha256 = "679305e32f4d7af08bedd2643fe09b2ee9d62ca381ba0267aefe2b5dc1295b42"
         autoupdate.asset.armhf = "syncserver-\\d+(\\.\\d+)+-trixie-armv7-unknown-linux-gnueabihf.zst"
 
         autoupdate.strategy = "latest_github_release"
         autoupdate.upstream = "https://github.com/YunoHost-Apps/syncstorage-rs-build"
         autoupdate.needs_manual_tweaks = true
-        autoupdate.version_regex = "syncserver-(\\d+\\.\\d+\\.\\d+\\.?\\d{0,})"
+        autoupdate.version_regex = "syncserver-(\\d+\\.\\d+\\.\\d+\\.?\\d{0,})-postgres"
         rename = "syncserver"
         in_subdir = false
         prefetch = false
 
         [resources.sources.diesel]
-        amd64.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/diesel-v2.3.11/diesel-v2.3.11-bookworm-x86_64-unknown-linux-gnu.zst"
-        amd64.sha256 = "a6091b8944ddd3949d1e8fef19dd3e1ca89563aec0272978b54a1decc517f00d"
+        amd64.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/diesel-v2.3.11-postgres/diesel-v2.3.11-bookworm-x86_64-unknown-linux-gnu.zst"
+        amd64.sha256 = "b2768061d0d6506bff0f3081bf356d7965911c478f4be3d6197525b3130e3ae2"
         autoupdate.asset.amd64 = "diesel-v\\d+(\\.\\d+)+-bookworm-x86_64-unknown-linux-gnu.zst"
 
-        arm64.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/diesel-v2.3.11/diesel-v2.3.11-bookworm-aarch64-unknown-linux-gnu.zst"
-        arm64.sha256 = "89b276a8203d17a0250ab5ea33dc1e3e4abe38d10ecd39e85d77b1afc4b00ba2"
+        arm64.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/diesel-v2.3.11-postgres/diesel-v2.3.11-bookworm-aarch64-unknown-linux-gnu.zst"
+        arm64.sha256 = "80b15a5f7e6cb745b605122fc382d3b7d8abe89a7d8940334e6844e5715537c3"
         autoupdate.asset.arm64 = "diesel-v\\d+(\\.\\d+)+-bookworm-aarch64-unknown-linux-gnu.zst"
 
-        armhf.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/diesel-v2.3.11/diesel-v2.3.11-bookworm-armv7-unknown-linux-gnueabihf.zst"
-        armhf.sha256 = "13119d7b7b92fb24414234b6ac8fc1e2082e51e16ff0b68a3bfdacb6ea6f1564"
+        armhf.url = "https://github.com/YunoHost-Apps/syncstorage-rs-build/releases/download/diesel-v2.3.11-postgres/diesel-v2.3.11-bookworm-armv7-unknown-linux-gnueabihf.zst"
+        armhf.sha256 = "992d3b724b544d54b5d8cd651f9d4036ee266f5e061dda7b2a6fff08e4b54829"
         autoupdate.asset.armhf = "diesel-v\\d+(\\.\\d+)+-bookworm-armv7-unknown-linux-gnueabihf.zst"
 
         autoupdate.strategy = "latest_github_release"
         autoupdate.upstream = "https://github.com/YunoHost-Apps/syncstorage-rs-build"
         autoupdate.needs_manual_tweaks = true
-        autoupdate.version_regex = "diesel-v(\\d+\\.\\d+\\.\\d+)"
+        autoupdate.version_regex = "diesel-v(\\d+\\.\\d+\\.\\d+)-postgres"
         rename = "diesel"
         in_subdir = false
 
         [resources.sources.uv]
-        amd64.url = "https://github.com/astral-sh/uv/releases/download/0.11.28/uv-x86_64-unknown-linux-gnu.tar.gz"
-        amd64.sha256 = "e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224"
-        arm64.url = "https://github.com/astral-sh/uv/releases/download/0.11.28/uv-aarch64-unknown-linux-gnu.tar.gz"
-        arm64.sha256 = "03e9fe0a81b0718d0bc84625de3885df6cc3f89a8b6af6121d6b9f6113fb6533"
-        armhf.url = "https://github.com/astral-sh/uv/releases/download/0.11.28/uv-armv7-unknown-linux-gnueabihf.tar.gz"
-        armhf.sha256 = "b7cddaad27cd531096e88e64de863f7e37c6fedde11c97595060e6503544d120"
+        amd64.url = "https://github.com/astral-sh/uv/releases/download/0.11.29/uv-x86_64-unknown-linux-gnu.tar.gz"
+        amd64.sha256 = "04f8b82f5d47f0512dcd32c67a4a6f16a0ea27c81537c338fd0ad6b23cebe829"
+        arm64.url = "https://github.com/astral-sh/uv/releases/download/0.11.29/uv-aarch64-unknown-linux-gnu.tar.gz"
+        arm64.sha256 = "94500fb064ae3c971a873cba64d94694c50677e0a4dbf78735c80509e7429919"
+        armhf.url = "https://github.com/astral-sh/uv/releases/download/0.11.29/uv-armv7-unknown-linux-gnueabihf.tar.gz"
+        armhf.sha256 = "7b5717ae304fbb1e94104699fb8c08b32d1537fedc90dd8fcf87768d818951ed"
 
         in_subdir = true
 
@@ -148,14 +148,14 @@ ram.runtime = "50M"
 
     [resources.apt]
     packages = [
-      "mariadb-server",
+      "postgresql",
       "libmariadb-dev-compat", 
       "build-essential",
       "libssl-dev",
       "libcurl4",
       "pkg-config",
-      "python3-dev"
+      "python3-dev",
     ]
 
     [resources.database]
-    type = "mysql"
+    type = "postgresql"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -17,27 +17,26 @@ myynh_build() {
 		ynh_exec_as_app "$install_dir/venv/bin/pip" install -r requirements.txt
 		ynh_exec_as_app "$install_dir/venv/bin/pip" install -r requirements-tokenserver.txt
 		ynh_print_info "Seeding the databases..."
-		mysql --version
 		./diesel --version
 		# syncstorage db
-		./diesel --database-url "mysql://$db_user:${db_pwd}@localhost/$db_name" migration --migration-dir syncstorage-mysql/migrations list
-		./diesel --database-url "mysql://$db_user:${db_pwd}@localhost/$db_name" migration --migration-dir syncstorage-mysql/migrations run
-		./diesel --database-url "mysql://$db_user:${db_pwd}@localhost/$db_name" migration --migration-dir syncstorage-mysql/migrations list
+		./diesel --database-url "postgres://$db_user:${db_pwd}@localhost/$db_name" migration --migration-dir syncstorage-postgres/migrations list
+		./diesel --database-url "postgres://$db_user:${db_pwd}@localhost/$db_name" migration --migration-dir syncstorage-postgres/migrations run
+		./diesel --database-url "postgres://$db_user:${db_pwd}@localhost/$db_name" migration --migration-dir syncstorage-postgres/migrations list
 
 		# tokenserver db
-		./diesel --database-url "mysql://$db_user:${db_pwd}@localhost/$db_name_tokenserver" migration --migration-dir tokenserver-mysql/migrations list
-		./diesel --database-url "mysql://$db_user:${db_pwd}@localhost/$db_name_tokenserver" migration --migration-dir tokenserver-mysql/migrations run
-		./diesel --database-url "mysql://$db_user:${db_pwd}@localhost/$db_name_tokenserver" migration --migration-dir tokenserver-mysql/migrations list
+		./diesel --database-url "postgres://$db_user:${db_pwd}@localhost/$db_name_tokenserver" migration --migration-dir tokenserver-postgres/migrations list
+		./diesel --database-url "postgres://$db_user:${db_pwd}@localhost/$db_name_tokenserver" migration --migration-dir tokenserver-postgres/migrations run
+		./diesel --database-url "postgres://$db_user:${db_pwd}@localhost/$db_name_tokenserver" migration --migration-dir tokenserver-postgres/migrations list
 
-		if [[ -z ${YNH_APP_UPGRADE_TYPE:-} ]]
+		if [[ -z ${YNH_APP_UPGRADE_TYPE:-} ]] || ynh_app_upgrading_from_version_before 0.23.3~ynh9
 		then
-		# Add a node on install only
-		pushd "tools/tokenserver"
-			ynh_hide_warnings ynh_exec_as_app \
-				SYNC_TOKENSERVER__DATABASE_URL="mysql://$db_user:${db_pwd}@localhost/$db_name_tokenserver" \
-					$install_dir/venv/bin/python add_node.py "https://${domain%%+(/)}" 10
-		popd
-	fi
+			# Add a node on install only
+			pushd "tools/tokenserver"
+				ynh_hide_warnings ynh_exec_as_app \
+					SYNC_TOKENSERVER__DATABASE_URL="postgres://$db_user:${db_pwd}@localhost/$db_name_tokenserver" \
+						$install_dir/venv/bin/python add_node.py "https://${domain%%+(/)}" 10
+			popd
+		fi
 	popd
 
 	ynh_safe_rm "$install_dir/.cache"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -17,16 +17,11 @@ myynh_build() {
 		ynh_exec_as_app "$install_dir/venv/bin/pip" install -r requirements.txt
 		ynh_exec_as_app "$install_dir/venv/bin/pip" install -r requirements-tokenserver.txt
 		ynh_print_info "Seeding the databases..."
-		./diesel --version
 		# syncstorage db
-		./diesel --database-url "postgres://$db_user:${db_pwd}@localhost/$db_name" migration --migration-dir syncstorage-postgres/migrations list
 		./diesel --database-url "postgres://$db_user:${db_pwd}@localhost/$db_name" migration --migration-dir syncstorage-postgres/migrations run
-		./diesel --database-url "postgres://$db_user:${db_pwd}@localhost/$db_name" migration --migration-dir syncstorage-postgres/migrations list
 
 		# tokenserver db
-		./diesel --database-url "postgres://$db_user:${db_pwd}@localhost/$db_name_tokenserver" migration --migration-dir tokenserver-postgres/migrations list
 		./diesel --database-url "postgres://$db_user:${db_pwd}@localhost/$db_name_tokenserver" migration --migration-dir tokenserver-postgres/migrations run
-		./diesel --database-url "postgres://$db_user:${db_pwd}@localhost/$db_name_tokenserver" migration --migration-dir tokenserver-postgres/migrations list
 
 		if [[ -z ${YNH_APP_UPGRADE_TYPE:-} ]] || ynh_app_upgrading_from_version_before 0.23.3~ynh9
 		then

--- a/scripts/backup
+++ b/scripts/backup
@@ -24,10 +24,10 @@ ynh_backup "/etc/systemd/system/$app.service"
 #=================================================
 # BACKUP THE DATABASE
 #=================================================
-ynh_print_info "Backing up the mysql database..."
+ynh_print_info "Backing up the database..."
 
-ynh_mysql_dump_db > db.sql
-ynh_mysql_dump_db "$db_name_tokenserver" > db_tokenserver.sql
+ynh_psql_dump_db > db.sql
+ynh_psql_dump_db "$db_name_tokenserver" > db_tokenserver.sql
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -21,7 +21,7 @@ ynh_config_change_url_nginx
 # Retarget worker nodes
 #=================================================
 
-ynh_mysql_db_shell "$db_name_tokenserver" <<< "UPDATE nodes set node='https://${new_domain%%+(/)}' WHERE node='https://${old_domain%%+(/)}'";
+ynh_psql_db_shell "$db_name_tokenserver" <<< "UPDATE nodes set node='https://${new_domain%%+(/)}' WHERE node='https://${old_domain%%+(/)}'";
 
 #=================================================
 # START SYSTEMD SERVICE

--- a/scripts/install
+++ b/scripts/install
@@ -35,14 +35,14 @@ chmod u+x "$install_dir/.uv/uv"
 #=================================================
 # PROVISION SECOND DB
 #=================================================
-ynh_script_progression "Configuring second MySQL database..."
+ynh_script_progression "Configuring second PostgreSQL database..."
 
-ynh_mysql_create_db "$db_name_tokenserver" "$db_user" "$db_pwd"
+ynh_psql_create_db "$db_name_tokenserver" "$db_user" "$db_pwd"
 
 #=================================================
 # BUILD
 #=================================================
-ynh_script_progression "Building the sources (it will take some time)..."
+ynh_script_progression "Provisioning the sources (it will take some time)..."
 
 myynh_build
 

--- a/scripts/remove
+++ b/scripts/remove
@@ -23,7 +23,7 @@ ynh_config_remove_logrotate
 #=================================================
 ynh_script_progression "Deprovisioning TokenServer DB..."
 
-ynh_mysql_drop_db "$db_name_tokenserver"
+ynh_psql_drop_db "$db_name_tokenserver"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/restore
+++ b/scripts/restore
@@ -11,14 +11,14 @@ ynh_script_progression "Restoring the app main directory..."
 ynh_restore "$install_dir"
 
 #=================================================
-# RESTORE THE MYSQL DATABASE
+# RESTORE THE POSTGRESQL DATABASE
 #=================================================
-ynh_script_progression "Restoring the MySQL database..."
+ynh_script_progression "Restoring the database..."
 
-ynh_mysql_db_shell < ./db.sql
+ynh_psql_db_shell < ./db.sql
 
-ynh_mysql_create_db "$db_name_tokenserver" "$db_user" "$db_pwd"
-ynh_mysql_db_shell "$db_name_tokenserver" < ./db_tokenserver.sql
+ynh_psql_create_db "$db_name_tokenserver" "$db_user" "$db_pwd"
+ynh_psql_db_shell "$db_name_tokenserver" < ./db_tokenserver.sql
 
 #=================================================
 # RESTORE SYSTEM CONFIGURATIONS

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -10,6 +10,11 @@ ynh_script_progression "Stopping $app's systemd service..."
 
 ynh_systemctl --service=$app --action="stop" --wait_until="Server closing"
 
+if ynh_app_upgrading_from_version_before 0.23.3~ynh9; then
+	ynh_script_progression "Configuring second PostgreSQL database..."
+	ynh_psql_create_db "$db_name_tokenserver" "$db_user" "$db_pwd"
+fi
+
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================


### PR DESCRIPTION
## Problem

- `libmariadb` broke compat with `libmysql`, rendering `diesel-rs` unusable

## Solution

- Switch to now upstream-supported PostgreSQL backend

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
